### PR TITLE
[INJIMOB-2670]: Removing ES256 from certify-mock-identity.properties

### DIFF
--- a/certify-mock-identity.properties
+++ b/certify-mock-identity.properties
@@ -104,7 +104,7 @@ mosip.certify.key-values={\
                     'scope' : 'mock_identity_vc_ldp',\
                     'cryptographic_binding_methods_supported': {'did:jwk'},\
                     'credential_signing_alg_values_supported': {'RsaSignature2018'},\
-                    'proof_types_supported': {'jwt': {'proof_signing_alg_values_supported': {'RS256', 'PS256', 'ES256'}}},\
+                    'proof_types_supported': {'jwt': {'proof_signing_alg_values_supported': {'RS256', 'PS256'}}},\
                     'credential_definition': {\
                       'type': {'VerifiableCredential','MockVerifiableCredential'},\
                       'credentialSubject': {\


### PR DESCRIPTION
[INJIMOB-2670]: Removing ES256 from certify-mock-identity.properties